### PR TITLE
Change to getSampleData

### DIFF
--- a/src/main/java/io/github/adrianmo/jmeter/backendlistener/azure/AzureBackendClient.java
+++ b/src/main/java/io/github/adrianmo/jmeter/backendlistener/azure/AzureBackendClient.java
@@ -206,7 +206,7 @@ public class AzureBackendClient extends AbstractBackendListenerClient {
         }
 
         if (logResponseData) {
-            properties.put("ResponseData", sr.getResponseDataAsString());
+            properties.put("ResponseData", sr.getSamplerData());
         }
 
         MapUtil.copy(properties, req.getProperties());


### PR DESCRIPTION
When running locally, `sr.getResponseDataAsString()` works. However, when running it in distributed testing env or on AKS like we are now, some data is missing. Not too sure why